### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cargo run
 Life is repetitive and most things in it come as series of items. Programmatically we often need to count, enumerate, and iterate over these sequences. There are several ways to generate repetition in programming languages. One of the most prominent constructs is C-style `for` loop with familiar syntax:
 
 ```c
-for ( x = 0; x < 10; x++ ) {
+for ( x = 0; x < 10; ++x ) {
   // do something
 }
 ```


### PR DESCRIPTION
Fixed the C-style example at the start to use the prefix-increment instead of postfix-increment. 

(Yes, both versions 'do the same' if your hope that the compiler will optimise the use of a postfix-increment for you. Using a prefix-increment is good style as it is more clear what the intention of the statement is (which is to increment the iteration index, and not to increment but return the old value). Nonetheless, many programmers (including myself for many years) do not know about this, and many tutorials/explanations list the postfix-version.

And this is of course exactly why iterator-based loops are so nice.