### PR TITLE
Fix itertools example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,11 +451,11 @@ for (country, rating) in top_contries {
 }
 
 // output:
-// # 1: Denmark
-// # 2: Switzerland
-// # 3: Iceland
-// # 4: Norway
-// # 5: Finland
+// # 1: Finland
+// # 2: Norway
+// # 3: Denmark
+// # 4: Iceland
+// # 5: Switzerland
 ```
 
 ## Creating Your Own Iterators


### PR DESCRIPTION
Thanks for the useful resource!

I spotted that the itertools example listed the countries result in wrong order, so here's a PR to fix the example output as verified by running it in Rust playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=574757bf85bf34173ec040fc1fce18d4

Cheers from Finland 😅 